### PR TITLE
Gracefully handle `Error` instances without a `stack` property

### DIFF
--- a/test.js
+++ b/test.js
@@ -26,3 +26,28 @@ test('main', t => {
 		Object.assign(new Error(), {code: 'EQUX'})
 	]);
 });
+
+test('gracefully handle Error instances without a stack', t => {
+	class StacklessError extends Error {
+		constructor(...args) {
+			super(...args);
+			this.name = this.constructor.name;
+			delete this.stack;
+		}
+	}
+
+	const error = new AggregateError([
+		new Error('foo'),
+		new StacklessError('stackless')
+	]);
+
+	console.log(error);
+
+	t.regex(error.message, /Error: foo\n {8}at /);
+	t.regex(error.message, /StacklessError: stackless/);
+
+	t.deepEqual([...error], [
+		new Error('foo'),
+		new StacklessError('stackless')
+	]);
+});


### PR DESCRIPTION
This fixes #6. I’ve added a test and included some documentation why the stack property is checked.

I thought about simply casting `error.stack` to a string, but that didn’t seem like a good idea (who knows if there are more fun exceptions to the `stack` property like array values). So I ended up with validating it as a string or String object (both of which implement `replace`, so that should be fine).

Feel free to change anything to your liking!

Thanks!