### PR TITLE
Change AggregateError constructor to accept any iterable, not just an array

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,7 +43,7 @@ declare class AggregateError extends Error implements Iterable<Error> {
 	//=> [Error: baz]
 	```
 	*/
-	constructor(errors: ReadonlyArray<Error | {[key: string]: unknown} | string>);
+	constructor(errors: Iterable<Error | {[key: string]: unknown} | string>);
 
 	[Symbol.iterator](): IterableIterator<Error>;
 }

--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ const cleanInternalStack = stack => stack.replace(/\s+at .*aggregate-error\/inde
 
 class AggregateError extends Error {
 	constructor(errors) {
-		if (!Array.isArray(errors)) {
-			throw new TypeError(`Expected input to be an Array, got ${typeof errors}`);
+		if (!errors || typeof errors[Symbol.iterator] !== 'function') {
+			throw new TypeError(`Expected input to be an Iterable, got ${typeof errors}`);
 		}
 
 		errors = [...errors].map(error => {

--- a/readme.md
+++ b/readme.md
@@ -55,7 +55,7 @@ Returns an `Error` that is also an [`Iterable`](https://developer.mozilla.org/en
 
 #### errors
 
-Type: `Array<Error|Object|string>`
+Type: `Iterable<Error|Object|string>`
 
 If a string, a new `Error` is created with the string as the error message.<br>
 If a non-Error object, a new `Error` is created with all properties from the object copied over.

--- a/test.js
+++ b/test.js
@@ -51,3 +51,22 @@ test('gracefully handle Error instances without a stack', t => {
 		new StacklessError('stackless')
 	]);
 });
+
+test('understands non-array iterables', t => {
+	function * generateErrors() {
+		yield new Error('first error');
+		yield new Error('second error');
+		yield new Error('third error');
+	}
+
+	const error = new AggregateError(generateErrors());
+
+	console.log(error);
+
+	const errors = [...error];
+	t.is(errors.length, 3);
+	errors.forEach(e => t.truthy(e instanceof Error));
+	t.is(errors[0].message, 'first error');
+	t.is(errors[1].message, 'second error');
+	t.is(errors[2].message, 'third error');
+});


### PR DESCRIPTION
The constructor creates a new array of the passed-in errors anyway, so why the restriction? This PR removes it; the constructor now only requires that the value of the `errors` parameter be an `Iterable`.