### PR TITLE
Optionally flatten nested AggregateErrors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -43,9 +43,17 @@ declare class AggregateError extends Error implements Iterable<Error> {
 	//=> [Error: baz]
 	```
 	*/
-	constructor(errors: ReadonlyArray<Error | {[key: string]: unknown} | string>);
+	constructor(errors: ReadonlyArray<Error | {[key: string]: unknown} | string>, options?: AggregateError.Options);
 
 	[Symbol.iterator](): IterableIterator<Error>;
+}
+
+declare namespace AggregateError {
+	/** Options for the AggregateError constructor. */
+	interface Options {
+		/** If true, nested AggregateErrors will be flattened. */
+		flatten?: boolean;
+	}
 }
 
 export = AggregateError;

--- a/readme.md
+++ b/readme.md
@@ -49,7 +49,7 @@ for (const individualError of error) {
 
 ## API
 
-### AggregateError(errors)
+### AggregateError(errors, options?)
 
 Returns an `Error` that is also an [`Iterable`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators#Iterables) for the individual errors.
 
@@ -59,6 +59,17 @@ Type: `Array<Error|Object|string>`
 
 If a string, a new `Error` is created with the string as the error message.<br>
 If a non-Error object, a new `Error` is created with all properties from the object copied over.
+
+#### options
+
+Type: `object`
+
+##### flatten
+
+Type: `boolean`<br>
+Default: `false`
+
+If `true`, nested `AggregateError`s will be flattened.
 
 
 ## License

--- a/test.js
+++ b/test.js
@@ -51,3 +51,30 @@ test('gracefully handle Error instances without a stack', t => {
 		new StacklessError('stackless')
 	]);
 });
+
+test('flattens nested AggregateErrors when told to', t => {
+	const testFlatErrors = [
+		new Error('first error'),
+		new Error('second error'),
+		new Error('third error')
+	];
+
+	const testErrors = [
+		new AggregateError([
+			testFlatErrors[0],
+			testFlatErrors[1]
+		]),
+		testFlatErrors[2]
+	];
+
+	const flatError = new AggregateError(testErrors, {flatten: true});
+	const flatErrors = [...flatError];
+	t.deepEqual(flatErrors, testFlatErrors);
+
+	const nestedError = new AggregateError(testErrors);
+	const nestedErrors = [...nestedError];
+	t.deepEqual(nestedErrors, testErrors);
+
+	console.log('Flattened:', flatError);
+	console.log('Not flattened:', nestedError);
+});


### PR DESCRIPTION
For example, consider a function that walks a folder tree:

```javascript
function walk(entry) {
	if (isFolder(entry)) {
		// List all entries in the folder. Walk each one. Collect errors thrown.
		const errors = [];
		
		for (const child of children(entry)) {
			try {
				walk(child);
			}
			catch (e) {
				errors.push(e);
			}
		}
		
		// If there are multiple errors, aggregate them.
		if (errors.size > 1)
			throw new AggregateError(errors);
		else if (errors.size)
			throw errors[0];
	}
	else {
		// Do something with the non-folder entry. Might throw an Error.
	}
}
```

This can produce a tree of nested `AggregateError`s, depending on how deep the folder tree is, which results in a very ugly stack trace. This PR fixes that by allowing the nested `AggregateError`s to be flattened.