### PR TITLE
Support custom `Error` subclass in the TypeScript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,8 @@
 /**
 Create an error from multiple errors.
 */
-declare class AggregateError extends Error implements Iterable<Error> {
+declare class AggregateError<T extends Error = Error> extends Error
+	implements Iterable<T> {
 	readonly name: 'AggregateError';
 
 	/**
@@ -43,9 +44,9 @@ declare class AggregateError extends Error implements Iterable<Error> {
 	//=> [Error: baz]
 	```
 	*/
-	constructor(errors: ReadonlyArray<Error | {[key: string]: any} | string>);
+	constructor(errors: ReadonlyArray<T | {[key: string]: any} | string>);
 
-	[Symbol.iterator](): IterableIterator<Error>;
+	[Symbol.iterator](): IterableIterator<T>;
 }
 
 export = AggregateError;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,8 +1,7 @@
 /**
 Create an error from multiple errors.
 */
-declare class AggregateError<T extends Error = Error> extends Error
-	implements Iterable<T> {
+declare class AggregateError<T extends Error = Error> extends Error implements Iterable<T> {
 	readonly name: 'AggregateError';
 
 	/**

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -13,11 +13,17 @@ for (const error of aggregateError) {
 	expectType<Error>(error);
 }
 
-interface CustomError extends Error {
-	foo: string;
+class CustomError extends Error {
+	public foo: string;
+
+	constructor(message: string) {
+		super(message)
+		this.name = 'CustomError'
+		this.foo = 'bar'
+	}
 }
 const customAggregateError = new AggregateError<CustomError>([
-	new Error('foo')
+	new CustomError('foo')
 ]);
 
 for (const error of customAggregateError) {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -12,3 +12,14 @@ expectType<IterableIterator<Error>>(aggregateError[Symbol.iterator]());
 for (const error of aggregateError) {
 	expectType<Error>(error);
 }
+
+interface CustomError extends Error {
+	foo: string;
+}
+const customAggregateError = new AggregateError<CustomError>([
+	new Error('foo')
+]);
+
+for (const error of customAggregateError) {
+	expectType<string>(error.foo);
+}

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -18,8 +18,8 @@ class CustomError extends Error {
 
 	constructor(message: string) {
 		super(message)
-		this.name = 'CustomError'
-		this.foo = 'bar'
+		this.name = 'CustomError';
+		this.foo = 'bar';
 	}
 }
 const customAggregateError = new AggregateError<CustomError>([


### PR DESCRIPTION
First of all thanks for the great library! We use it in `semantic-release` and love it!

I'm now looking into using it in [`@octokit/webhooks`](https://github.com/octokit/webhooks) in order to address https://github.com/octokit/webhooks.js/issues/182

We use a custom Error type for request errors, which are the most common error types in webhook event handlers, so I'd like to provide better intellisense when users interact with the errors from the AggregatedError array. In order to make that possible, the Error type used by would need to be customizeable. That's what I do in this pull request.

Sorry for not opening an issue first, I figured it would be easier to reason about the implementation details in a pull request