### PR TITLE
Remove redundant array cloning

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ class AggregateError extends Error {
 			throw new TypeError(`Expected input to be an Array, got ${typeof errors}`);
 		}
 
-		errors = [...errors].map(error => {
+		errors = errors.map(error => {
 			if (error instanceof Error) {
 				return error;
 			}


### PR DESCRIPTION
`Array#map` always returns a new array:

```js
var a = []
var b = a.map(x => x)

a === b // => false
```

Also `errors` has been asserted to be an array, therefore no need to manually convert non-array iterables (`Set`, `Map`, etc.) into arrays by using `[ ...iterable ]`.