### PR TITLE
Handles empty stack strings.

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ export default class AggregateError extends Error {
 		let message = errors
 			.map(error => {
 				// The `stack` property is not standardized, so we can't assume it exists
-				return typeof error.stack === 'string' ? cleanInternalStack(cleanStack(error.stack)) : String(error);
+				return error.stack && typeof error.stack === 'string' ? cleanInternalStack(cleanStack(error.stack)) : String(error);
 			})
 			.join('\n');
 		message = '\n' + indentString(message, 4);

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ export default class AggregateError extends Error {
 		let message = errors
 			.map(error => {
 				// The `stack` property is not standardized, so we can't assume it exists
-				return error.stack && typeof error.stack === 'string' ? cleanInternalStack(cleanStack(error.stack)) : String(error);
+				return typeof error.stack === 'string' && error.stack.length > 0 ? cleanInternalStack(cleanStack(error.stack)) : String(error);
 			})
 			.join('\n');
 		message = '\n' + indentString(message, 4);

--- a/test.js
+++ b/test.js
@@ -51,3 +51,28 @@ test('gracefully handle Error instances without a stack', t => {
 		new StacklessError('stackless')
 	]);
 });
+
+test('gracefully handle Error instances with empty stack', t => {
+	class EmptyStackError extends Error {
+		constructor(...args) {
+			super(...args);
+			this.name = this.constructor.name;
+			this.stack = '';
+		}
+	}
+
+	const error = new AggregateError([
+		new Error('foo'),
+		new EmptyStackError('emptystack')
+	]);
+
+	console.log(error);
+
+	t.regex(error.message, /Error: foo\n {8}at /);
+	t.regex(error.message, /EmptyStackError: emptystack/);
+
+	t.deepEqual([...error.errors], [
+		new Error('foo'),
+		new EmptyStackError('emptystack')
+	]);
+});


### PR DESCRIPTION
`ESLintError` clears its stacktrace: https://github.com/webpack-contrib/eslint-webpack-plugin/blob/08af5d683394ec0156aaa61d4c204d4181e76fb0/src/ESLintError.js#L8

The result was an empty `AggregateErrors:` message. The importer of `aggregate-error` is the [`instant-mocha`](https://github.com/privatenumber/instant-mocha) test runner.